### PR TITLE
Add plugin name for v4

### DIFF
--- a/todo-list.qml
+++ b/todo-list.qml
@@ -7,6 +7,12 @@ import Qt.labs.settings 1.0
 
 MuseScore {
     id: plugin
+    Component.onCompleted: {
+            if (mscoreMajorVersion >= 4) {
+               plugin.title = qsTr("To-Do List")
+               
+            }
+      }
     description: "Scans the score for TODO and FIXME text elements."
     version: "3.0.0"
     menuPath: "Plugins.To-Do List"


### PR DESCRIPTION
Fixed issue where plugin name would not display in v4 menu (based off ecstrema/breaksExporter)